### PR TITLE
Add animation blending

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .git/
 .vs/
 libs/
+lib/
 obj/
 bin/
 *.sln

--- a/BoostAbility.cs
+++ b/BoostAbility.cs
@@ -263,6 +263,11 @@ namespace trickyclown
         public static ConfigEntry<bool> enableFramerideSoundCfg;
         public static BPatchTC Instance { get; private set; }
 
+        public static ConfigEntry<bool> enableAnimationBlending;
+        public static ConfigEntry<float> defaultAnimationBlendingIn;
+        public static ConfigEntry<float> defaultAnimationBlendingOut;
+        public static ConfigEntry<string> customAnimationBlending;
+
         private Dictionary<string, ConfigEntry<string>> configEntries;
 
         public static ConfigEntry<float> wallslideSpeed;
@@ -272,6 +277,13 @@ namespace trickyclown
             BPatchTC.enableSwitchCfg = base.Config.Bind<bool>("General", "enableSwitchCfg", false, "Disable Boost Switching to On-foot (Leave this false if you're doing vanilla score attack or your run will be considered invalid.)");
             BPatchTC.enableFramerideCfg = base.Config.Bind<bool>("General", "enableFramerideCfg", false, "Enables frameride trick name/score (Leave this false if you're doing vanilla score attack or your run will be considered invalid.)");
             BPatchTC.enableFramerideSoundCfg = base.Config.Bind<bool>("General", "enableFramerideSoundCfg", false, "Enables frameride sound.");
+
+            BPatchTC.enableAnimationBlending = base.Config.Bind<bool>("General", "enableAnimationBlending", false, "Enables smooth animation blending between animations. May cause strange/broken movement with certain animations.");
+            BPatchTC.defaultAnimationBlendingIn = base.Config.Bind<float>("General", "defaultAnimationBlendingIn", 0f, "Default blend time transitioning into BOE animations (in seconds). When transitioning from one BOE animation to another, defaultAnimationBlendingOut takes priority");
+            BPatchTC.defaultAnimationBlendingOut = base.Config.Bind<float>("General", "defaultAnimationBlendingOut", 0.2f, "Default blend time transitioning out of BOE animations (in seconds)");
+            
+            BPatchTC.customAnimationBlending = base.Config.Bind<string>("General", "customAnimationBlending", "", "Overrides defaults. Use asterisk (*) as a wildcard for any animations (vanilla or BOE). Separate rules with commas. Acceptable formats: animationIn>animationOut:blendTime, animation:outBlendTime, animation1>animation2>animation3:inOutBlendTime,"); 
+            BPatchTC.customAnimationBlending.SettingChanged += (a,b) => { ABPatchesTC.ParseCustomBlending(); };
 
             Instance = this;
 

--- a/BoostAbility.cs
+++ b/BoostAbility.cs
@@ -278,11 +278,11 @@ namespace trickyclown
             BPatchTC.enableFramerideCfg = base.Config.Bind<bool>("General", "enableFramerideCfg", false, "Enables frameride trick name/score (Leave this false if you're doing vanilla score attack or your run will be considered invalid.)");
             BPatchTC.enableFramerideSoundCfg = base.Config.Bind<bool>("General", "enableFramerideSoundCfg", false, "Enables frameride sound.");
 
-            BPatchTC.enableAnimationBlending = base.Config.Bind<bool>("General", "enableAnimationBlending", false, "Enables smooth animation blending between animations. May cause strange/broken movement with certain animations.");
+            BPatchTC.enableAnimationBlending = base.Config.Bind<bool>("General", "enableAnimationBlending", true, "Enables smooth animation blending between animations. May cause strange/broken movement with certain animations.");
             BPatchTC.defaultAnimationBlendingIn = base.Config.Bind<float>("General", "defaultAnimationBlendingIn", 0f, "Default blend time transitioning into BOE animations (in seconds). When transitioning from one BOE animation to another, defaultAnimationBlendingOut takes priority");
-            BPatchTC.defaultAnimationBlendingOut = base.Config.Bind<float>("General", "defaultAnimationBlendingOut", 0.2f, "Default blend time transitioning out of BOE animations (in seconds)");
+            BPatchTC.defaultAnimationBlendingOut = base.Config.Bind<float>("General", "defaultAnimationBlendingOut", 0.1f, "Default blend time transitioning out of BOE animations (in seconds)");
             
-            BPatchTC.customAnimationBlending = base.Config.Bind<string>("General", "customAnimationBlending", "", "Overrides defaults. Use asterisk (*) as a wildcard for any animations (vanilla or BOE). Separate rules with commas. Acceptable formats: animationIn>animationOut:blendTime, animation:outBlendTime, animation1>animation2>animation3:inOutBlendTime,"); 
+            BPatchTC.customAnimationBlending = base.Config.Bind<string>("General", "customAnimationBlending", "", "Overrides default blend time for specified animations. Use asterisk (*) as a wildcard for any animations (vanilla or BOE). Separate rules with commas. Acceptable formats: animation:inBlend/outBlend, animation:outBlend, animationIn>animationOut:blend, animation1>animation2>animation3:blend, animation1>animation2>animation3:inBlend/outBlend"); 
             BPatchTC.customAnimationBlending.SettingChanged += (a,b) => { ABPatchesTC.ParseCustomBlending(); };
 
             Instance = this;

--- a/BunchOfEmotesSupport.cs
+++ b/BunchOfEmotesSupport.cs
@@ -49,5 +49,7 @@ namespace trickyclown
                 return true;
             return false;
         }
+
+        public static bool GameAnimationIsCustomAnimation(int gameAnim) { return GameAnimationByCustomAnimation.ContainsValue(gameAnim); }
     }
 }

--- a/PlayerAnimPatches.cs
+++ b/PlayerAnimPatches.cs
@@ -1,0 +1,209 @@
+using BepInEx;
+using BepInEx.Configuration;
+using BepInEx.Logging;
+using HarmonyLib;
+using Reptile;
+using UnityEngine;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace trickyclown
+{
+    public class ABPatchesTC
+    {
+        public static Dictionary<int, Dictionary<int, float>> customBlendingFromTo = new();
+        public static Dictionary<int, float> alwaysBlendOut = new(); 
+        public static Dictionary<int, float> alwaysBlendIn = new();
+
+        public static void ParseCustomBlending()
+        {
+            customBlendingFromTo.Clear();
+            alwaysBlendIn.Clear();
+            alwaysBlendOut.Clear();
+
+            string customsUnsplit = BPatchTC.customAnimationBlending.Value;
+            if (string.IsNullOrWhiteSpace(customsUnsplit)) return;
+
+            string[] customs = customsUnsplit.Replace(", ", ",").Split(new char[]{','}, StringSplitOptions.RemoveEmptyEntries);
+            foreach (string custom in customs)
+            {
+                string trimmedCustom = custom.Trim();
+                if (string.IsNullOrWhiteSpace(trimmedCustom)) continue;
+                try
+                {
+                    int colonIndex = trimmedCustom.LastIndexOf(':');
+                    if (colonIndex == -1) 
+                        throw new FormatException("Missing blend time separator (:)");
+
+                    string selector = trimmedCustom.Substring(0, colonIndex);
+                    string blendValueString = trimmedCustom.Substring(colonIndex + 1);
+
+                    if (!float.TryParse(blendValueString, out float blend))
+                        throw new FormatException($"Blend time '{blendValueString}' invalid - check formatting");
+
+                    string[] splitByArrows = selector.Split('>');
+                    switch (splitByArrows.Length)
+                    {
+                        case 1: // "animation:outBlend" (equivalent to "animation>*:blend")
+                            HandleSingleAnimationRule(splitByArrows[0], blend);
+                            break;
+                        case 2: // "animation1>animation2:blend"
+                            HandleTwoAnimationRule(splitByArrows[0], splitByArrows[1], blend);
+                            break;
+                        case 3: // "animation1>animation2>animation3:inOutBlend"
+                            HandleThreeAnimationRule(splitByArrows[0], splitByArrows[1], splitByArrows[2], blend);
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException("Improper formatting - number of arrows (>) outside of range (0-2)");
+                    }
+                } catch (Exception ex) {
+                    Debug.LogWarning($"(NewTrix/ABPatchesTC) Failed parsing custom animation blending string '{trimmedCustom}': {ex.Message}");
+                }
+            }
+        }
+
+        private static void HandleSingleAnimationRule(string fromPart, float blend)
+        {
+            int animationFrom = AnimationUtility.GetAnimationByName(fromPart.Trim());
+            alwaysBlendOut[animationFrom] = blend;
+        }
+
+        private static void HandleTwoAnimationRule(string fromPart, string toPart, float blend)
+        {
+            string trimmedFrom = fromPart.Trim();
+            string trimmedTo = toPart.Trim();
+
+            bool alwaysOut = trimmedTo == "*";
+            bool alwaysIn = trimmedFrom == "*";
+
+            if (alwaysOut && alwaysIn)
+            {
+                throw new Exception("Improper rule - use defaultAnimationBlend in config instead!");
+            }
+            else if (alwaysOut)
+            {
+                int animationFrom = AnimationUtility.GetAnimationByName(trimmedFrom);
+                alwaysBlendOut[animationFrom] = blend;
+            }
+            else if (alwaysIn)
+            {
+                int animationTo = AnimationUtility.GetAnimationByName(trimmedTo);
+                alwaysBlendIn[animationTo] = blend;
+            }
+            else
+            {
+                int animationFrom = AnimationUtility.GetAnimationByName(trimmedFrom);
+                int animationTo = AnimationUtility.GetAnimationByName(trimmedTo);
+                AddCustomBlending(animationFrom, animationTo, blend);
+            }
+        }
+
+        private static void HandleThreeAnimationRule(string fromPart, string middlePart, string toPart, float blend)
+        {
+            string trimmedStart = fromPart.Trim();
+            string trimmedMiddle = middlePart.Trim();
+            string trimmedEnd = toPart.Trim();
+
+            bool alwaysOut = trimmedStart == "*";
+            bool alwaysIn = trimmedEnd == "*";
+
+            if (trimmedMiddle == "*")
+                throw new Exception("Improper rule - use defaultAnimationBlend in config instead!");
+
+            if (alwaysOut && alwaysIn)
+            {
+                int animationMiddle = AnimationUtility.GetAnimationByName(trimmedMiddle);
+                alwaysBlendIn[animationMiddle] = blend;
+                alwaysBlendOut[animationMiddle] = blend;
+            }
+            else if (alwaysOut)
+            {
+                int animationFrom = AnimationUtility.GetAnimationByName(trimmedStart);
+                int animationMiddle = AnimationUtility.GetAnimationByName(trimmedMiddle);
+                alwaysBlendOut[animationMiddle] = blend;
+                AddCustomBlending(animationFrom, animationMiddle, blend);
+            }
+            else if (alwaysIn)
+            {
+                int animationMiddle = AnimationUtility.GetAnimationByName(trimmedMiddle);
+                int animationTo = AnimationUtility.GetAnimationByName(trimmedEnd);
+                alwaysBlendIn[animationMiddle] = blend;
+                AddCustomBlending(animationMiddle, animationTo, blend);
+            }
+            else
+            {
+                int animationFrom = AnimationUtility.GetAnimationByName(trimmedStart);
+                int animationMiddle = AnimationUtility.GetAnimationByName(trimmedMiddle);
+                int animationTo = AnimationUtility.GetAnimationByName(trimmedEnd);
+                AddCustomBlending(animationFrom, animationMiddle, blend);
+                AddCustomBlending(animationMiddle, animationTo, blend);
+            }
+        }
+
+        private static void AddCustomBlending(int animationFrom, int animationTo, float blend) {
+            if (!customBlendingFromTo.ContainsKey(animationFrom)) { customBlendingFromTo[animationFrom] = new(); }
+            Dictionary<int, float> value = customBlendingFromTo[animationFrom];
+            value[animationTo] = blend;
+            customBlendingFromTo[animationFrom] = value; 
+            //Debug.Log($"{animationFrom} -->> {animationTo} equals {blend}");
+        }
+
+        public static bool TryGetAnimationBlendValue(int animationFrom, int animationTo, out float blendReturnValue) 
+        {
+            float blendValue = 0f;
+
+            if (alwaysBlendOut.TryGetValue(animationFrom, out blendValue)) {
+                blendReturnValue = blendValue; 
+                return true; 
+            } else if (alwaysBlendIn.TryGetValue(animationTo, out blendValue)) {
+                blendReturnValue = blendValue; 
+                return true; 
+            } 
+
+            if (customBlendingFromTo.TryGetValue(animationFrom, out Dictionary<int, float> value)) 
+            { 
+                if (value.TryGetValue(animationTo, out blendValue)) 
+                { 
+                    blendReturnValue = blendValue; 
+                    return true; 
+                }
+            } 
+
+            bool fromIsBOEAnim = BunchOfEmotesSupport.Installed ? BunchOfEmotesSupport.GameAnimationIsCustomAnimation(animationFrom) : false;
+            bool toIsBOEAnim = BunchOfEmotesSupport.Installed ? BunchOfEmotesSupport.GameAnimationIsCustomAnimation(animationTo) : false;
+
+            if (fromIsBOEAnim) { blendReturnValue = BPatchTC.defaultAnimationBlendingOut.Value; }
+            else if (toIsBOEAnim) { blendReturnValue = BPatchTC.defaultAnimationBlendingIn.Value; }
+            else { blendReturnValue = 0f; }
+            return false;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(Player), nameof(Player.PlayAnim))]
+        public static bool PlayAnimBlendingPrefix(int newAnim, bool forceOverwrite, bool instant, float atTime, Player __instance) 
+        {
+            if (__instance != WorldHandler.instance?.GetCurrentPlayer()) return true;
+
+            if (!BPatchTC.enableAnimationBlending.Value || !__instance.gameObject.activeSelf 
+            || (newAnim == __instance.curAnim && !forceOverwrite)) { return true; }
+
+            bool isFallbackBlendValue = TryGetAnimationBlendValue(__instance.curAnim, newAnim, out var blendValue);        
+            //Debug.Log($"{__instance.curAnim} -->> {newAnim} equals {blendValue} (is fallback: {isFallbackBlendValue})");    
+			if (blendValue > 0 && !instant && atTime == -1f) //&& !__instance.animInfos.ContainsKey(__instance.curAnim))
+			{
+				__instance.anim.CrossFade(newAnim, blendValue);
+                __instance.curAnimActiveTime = 0f;
+                __instance.firstFrameAnim = true;
+                __instance.characterVisual.feetIK = __instance.animInfos.ContainsKey(newAnim) && __instance.animInfos[newAnim].feetIK;
+                __instance.curAnim = newAnim;
+                return false; 
+			}
+            
+            return true;
+        }
+    }
+
+}

--- a/PlayerAnimPatches.cs
+++ b/PlayerAnimPatches.cs
@@ -107,12 +107,12 @@ namespace trickyclown
         {
             int animation = AnimationUtility.GetAnimationByName(fromPart.Trim());
             if (blend.Count() == 1) { 
-                if (importantRule) { importantRules.Add(PartsToRule(fromPart, "*", blend[0])); }
+                if (importantRule) { importantRules.Add(PartsToRule(animation.ToString(), "*", blend[0])); }
                 AlwaysBlendOut(animation, blend[0]);
             } else if (blend.Count() == 2) { 
                 if (importantRule) { 
-                    importantRules.Add(PartsToRule("*", fromPart, blend[0]));
-                    importantRules.Add(PartsToRule(fromPart, "*", blend[1])); 
+                    importantRules.Add(PartsToRule("*", animation.ToString(), blend[0]));
+                    importantRules.Add(PartsToRule(animation.ToString(), "*", blend[1])); 
                 }
                 AlwaysBlendIn(animation, blend[0]);
                 AlwaysBlendOut(animation, blend[1]);
@@ -120,25 +120,27 @@ namespace trickyclown
         }
 
         private static void HandleTwoAnimationRule(string fromPart, string toPart, float blend, bool importantRule) {
-            if (importantRule) { importantRules.Add(PartsToRule(fromPart, toPart, blend)); }
-
             string trimmedFrom = fromPart.Trim();
             string trimmedTo = toPart.Trim();
             bool alwaysOut = trimmedTo == "*";
             bool alwaysIn = trimmedFrom == "*";
 
+            if (importantRule) { 
+                importantRules.Add(PartsToRule(
+                    (string)(alwaysIn ? "*" : AnimationUtility.GetAnimationByName(trimmedFrom).ToString()), 
+                    (string)(alwaysOut ? "*" : AnimationUtility.GetAnimationByName(trimmedTo).ToString()), 
+                    blend
+                )); 
+            }
+
             if (alwaysOut && alwaysIn) {
                 throw new Exception("Improper rule - use defaultAnimationBlend in config instead!");
             } else if (alwaysOut) {
-                int animationFrom = AnimationUtility.GetAnimationByName(trimmedFrom);
-                AlwaysBlendOut(animationFrom, blend);
+                AlwaysBlendOut(AnimationUtility.GetAnimationByName(trimmedFrom), blend);
             } else if (alwaysIn) {
-                int animationTo = AnimationUtility.GetAnimationByName(trimmedTo);
-                AlwaysBlendIn(animationTo, blend);
+                AlwaysBlendIn(AnimationUtility.GetAnimationByName(trimmedTo), blend);
             } else {
-                int animationFrom = AnimationUtility.GetAnimationByName(trimmedFrom);
-                int animationTo = AnimationUtility.GetAnimationByName(trimmedTo);
-                AddCustomBlending(animationFrom, animationTo, blend);
+                AddCustomBlending(AnimationUtility.GetAnimationByName(trimmedFrom), AnimationUtility.GetAnimationByName(trimmedTo), blend);
             }
         }
 
@@ -201,7 +203,7 @@ namespace trickyclown
             // 1. important custom rule
             if (hasCustomRule)
             {
-                string specificRule = PartsToRule(animationFrom, animationTo, customBlendValue);
+                string specificRule = PartsToRule(animationFrom.ToString(), animationTo.ToString(), customBlendValue);
                 if (IsImportantRule(specificRule) || !(hasAlwaysOut || hasAlwaysIn))
                 {
                     blendReturnValue = customBlendValue;

--- a/PlayerAnimPatches.cs
+++ b/PlayerAnimPatches.cs
@@ -195,8 +195,10 @@ namespace trickyclown
         {
             // hierarchy: important custom rule > important alwaysInOut > custom rule > alwaysInOut > fallbacks > 0f
 
-            bool hasCustomRule = customBlendingFromTo.TryGetValue(animationFrom, out Dictionary<int, float> customRules) 
-                && customRules.TryGetValue(animationTo, out float customBlendValue);
+            float customBlendValue = 0;
+            bool hasCustomRule = customBlendingFromTo.TryGetValue(animationFrom, out Dictionary<int, float> customRules);
+            if (hasCustomRule) { hasCustomRule = customRules.TryGetValue(animationTo, out customBlendValue); }
+
             bool hasAlwaysOut = alwaysBlendOut.TryGetValue(animationFrom, out float alwaysOutValue);
             bool hasAlwaysIn = alwaysBlendIn.TryGetValue(animationTo, out float alwaysInValue);
 

--- a/PlayerAnimPatches.cs
+++ b/PlayerAnimPatches.cs
@@ -29,6 +29,7 @@ namespace trickyclown
             string customsUnsplit = BPatchTC.customAnimationBlending.Value;
             if (string.IsNullOrWhiteSpace(customsUnsplit)) return;
 
+            int numberOfFailures = 0;
             string[] customs = customsUnsplit.Replace(", ", ",").Split(new char[]{','}, StringSplitOptions.RemoveEmptyEntries);
             foreach (string custom in customs)
             {
@@ -53,9 +54,13 @@ namespace trickyclown
                         ParseSelectorValuePair(selector, blendValueString, importantRule); 
                     }
                 } catch (Exception ex) {
-                    Debug.LogWarning($"(NewTrix/ABPatchesTC) Failed parsing custom animation blending string '{trimmedCustom}': {ex.Message}");
+                    Debug.LogWarning($"(NewTrix/AB) Failed parsing custom animation blending string '{trimmedCustom}': {ex.Message}");
+                    numberOfFailures++; 
                 }
             }
+
+            if (numberOfFailures == 0) { Debug.Log("(NewTrix/AB) All custom animation blending options successfully parsed!"); }
+            else { Debug.LogWarning($"(NewTrix/AB) All custom animation blending options parsed with {numberOfFailures} failures)"); }
         }
 
         public static void ParseSelectorValuePair(string selector, string blendValueString, bool importantRule = false) {

--- a/PlayerAnimPatches.cs
+++ b/PlayerAnimPatches.cs
@@ -195,7 +195,7 @@ namespace trickyclown
         {
             // hierarchy: important custom rule > important alwaysInOut > custom rule > alwaysInOut > fallbacks > 0f
 
-            float customBlendValue = 0;
+            float customBlendValue = 0f;
             bool hasCustomRule = customBlendingFromTo.TryGetValue(animationFrom, out Dictionary<int, float> customRules);
             if (hasCustomRule) { hasCustomRule = customRules.TryGetValue(animationTo, out customBlendValue); }
 

--- a/PlayerAnimPatches.cs
+++ b/PlayerAnimPatches.cs
@@ -14,6 +14,7 @@ namespace trickyclown
 {
     public class ABPatchesTC
     {
+        public static bool ParsedOptions { get; private set; } = false;
         public static Dictionary<int, Dictionary<int, float>> customBlendingFromTo = new();
         public static Dictionary<int, float> alwaysBlendOut = new(); 
         public static Dictionary<int, float> alwaysBlendIn = new();
@@ -61,6 +62,7 @@ namespace trickyclown
 
             if (numberOfFailures == 0) { Debug.Log("(NewTrix/AB) All custom animation blending options successfully parsed!"); }
             else { Debug.LogWarning($"(NewTrix/AB) All custom animation blending options parsed with {numberOfFailures} failures)"); }
+            ParsedOptions = true;
         }
 
         public static void ParseSelectorValuePair(string selector, string blendValueString, bool importantRule = false) {
@@ -253,6 +255,12 @@ namespace trickyclown
 
             blendReturnValue = 0f;
             return false;
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(StageManager), nameof(StageManager.DoStagePostInitialization))]
+        public static void CheckToParse() {
+            if (!ParsedOptions) ParseCustomBlending();
         }
 
         [HarmonyPrefix]

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -42,6 +42,7 @@ namespace trickyclown
             harmony.PatchAll(typeof(SlideAbilityPatches));
             harmony.PatchAll(typeof(WallrunLineAbilityPatches));
             harmony.PatchAll(typeof(VertAbilityPatches2));
+            harmony.PatchAll(typeof(ABPatchesTC));
             harmony.PatchAll();
             Logger.LogInfo($"Trix R 4 Kidz");
             SceneManager.sceneLoaded += OnSceneLoaded;


### PR DESCRIPTION
new ConfigTrixMisc options:

- enableAnimationBlending: whether smoothing is enabled at all. enabled by default
- defaultAnimationBlendingIn: transitioning *into* BOE animations 
- defaultAnimationBlendingOut: transitioning *out of* BOE animations
- customAnimationBlending: special string for special per-anim selectors, separated by commas. acceptable formats:
   - "animation:outBlend" (when transitioning out of `animation`, take `outBlend` seconds)
   - **"animation:inBlend/outBlend"** (when transitioning into `animation`, take `inBlend` seconds. when transitioning out of `animation` into any other, take `outBlend` seconds)
      - probably the most broadly useful rule
   - "animation1>animation2:blend" (when transitioning from `animation1` to `animation2`, take `blend` seconds)
   - "animation1>animation2>animation3:inOutBlend" (when transitioning from `animation1` to `animation2`, take `inOutBlend` seconds. when transitioning from `animation2` to `animation3`, take `inOutBlend` seconds.)
   - "animation1>animation2>animation3:inBlend/outBlend" (when transitioning from `animation1` to `animation2`, take `inBlend` seconds. when transitioning from `animation2` to `animation3`, take `outBlend` seconds.)
   - use asterisk as a synonym for ANY animation
   - use exclamation point to mark a rule as important
      - important rules override other rules AND the "instant" boolean check (so it basically always applies)
   - there is All New Behavior of having multiple selectors for the same value by separating them w |, something like "animation1>animation2|animation3|*>animation4:0!". i'm pretty sure this works anyway
   - for example, "\*>boostRun:5!" means "when transitioning *from* any animation (\*) *to* boostRun, take 5 whole seconds to do it, **every single time** (!). this rule has no effect on the transition period *out of* boostRun